### PR TITLE
Update sloshy.yaml

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -16,6 +16,9 @@ rooms:
    - name: "Duck Overflow"
      id: 193903
      contact: samcarter (3270911)
+   - name: "shree's room"
+     id: 232981
+     contact: Shree (965146)
  - chat.meta.stackexchange.com:
    - name: "The Friendly Café (room for testing bots on Meta.SE)"
      id: 1543


### PR DESCRIPTION
Add a new room.
The room is dedicated to catching NLN (no longer needed) comments via API and automatically flagging if necessary and sending them to the chat room .  Script is registered on  stackapps (https://stackapps.com/questions/8945/placeholder-user-script-for-auto-flag-nln-no-longer-needed-comment).