### PR TITLE
Add two rooms on the watch list

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -19,6 +19,12 @@ rooms:
    - name: "shree's room"
      id: 232981
      contact: Shree (965146)
+   - name: "V-eye"
+     id: 239515
+     contact: oleg-valter (15810379)
+   - name: "Google Apps Script chat community"
+     id: 217630
+     contact: oleg-valter (15810379)
  - chat.meta.stackexchange.com:
    - name: "The Friendly Café (room for testing bots on Meta.SE)"
      id: 1543


### PR DESCRIPTION
This PR humbly makes a request to include two more rooms on the watch list:
- Google Apps Script chat community (of which I am one of the ROs)
- V-eye (personal room for monitoring/managing FAQ proposals)