### PR TITLE
Add two more rooms to the watchlist

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -22,6 +22,9 @@ rooms:
    - name: "Google Apps Script chat community"
      id: 217630
      contact: oleg-valter (15810379)
+   - name: "V-eye"
+     id: 240030
+     contact: oleg-valter (15810379)
  - chat.stackexchange.com:
    - name: "Matter Modeling: Meta"
      id: 113019
@@ -98,3 +101,6 @@ rooms:
    - name: "Physics questions at MMSE"
      id: 111122
      contact: user1271772 (1327177)
+   - name: "Room for testing ElectionBot on *.stackexchange.com elections"
+     id: 92073
+     contact: oleg-valter (15810379)


### PR DESCRIPTION
This PR adds two more rooms to Sloshy's watchlist:

- V-eye (keeping track of FAQ-proposals) as a follow-up to #18
- ElectionBot development room on the chat.stackexchange.com domain