### PR TITLE
Add SpotDetector dev room to the antifreeze list

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -109,4 +109,7 @@ servers:
     - contact: oleg-valter (15810379)
       name: "V-eye"
       id: 240030
+    - contact: oleg-valter (15810379)
+      name: "[dev] SpotDetector"
+      id: 244392
     sloshy_id: 16115299


### PR DESCRIPTION
This PR adds a SpotDetector [development room](https://chat.stackoverflow.com/rooms/244392/dev-spotdetector) over on Stack Overflow to the list of rooms that are watched for inactivity.