### PR TITLE
Add Chem.SE's "Downvoting" room

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -99,6 +99,9 @@ servers:
     - contact: peter-k (7274)
       name: "Signal Processing: Post-Processing"
       id: 1090     
+    - contact: user1271772 (1327177)
+      name: "Chemistry: Downvoting"
+      id: 138453     
     sloshy_id: 514718
   chat.stackoverflow.com:
     rooms:


### PR DESCRIPTION
Permission to add Sloshy was granted by Karsten (an elected diamond moderator on the parent site, Chemistry.SE, and also the user that created the room): https://chat.stackexchange.com/transcript/message/61953167#61953167

Discussions about unfreezing the room so that Sloshy could be installed, also took place with Buck Thorn and Tyberius (both of them are elected diamond moderators on Chem.SE).