### PR TITLE
Add The Terminal to the list

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -105,6 +105,9 @@ servers:
     - contact: user1271772 (1327177)
       name: "Operations Research: General"
       id: 94323
+    - contact: gparyani (2477436)
+      name: "The Terminal"
+      id: 84778
     sloshy_id: 514718
   chat.stackoverflow.com:
     rooms:


### PR DESCRIPTION
SmokeDetector's messages were the ones keeping this room alive. However, it has been disabled due to the June 2023 moderation strike, so there is nothing keeping the room from freezing.