### PR TITLE
Add sopython meta rooms

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -157,4 +157,10 @@ servers:
     - contact: M-- (8629256)
       name: "R Language Collective"
       id: 252171
+    - contact: Andras Deak (6553924)
+      name: "Python Ouroboros - The Rotating Knives"
+      id: 71097
+    - contact: Andras Deak (6553924)
+      name: "MetaPython"
+      id: 202427
     sloshy_id: 16115299


### PR DESCRIPTION
Add Python meta rooms:
  * [the Ouroboros](https://chat.stackoverflow.com/rooms/info/71097/python-ouroboros-the-rotating-knives), our friendly trash room (I've given write access to Sloshy)
  * [MetaPython](https://chat.stackoverflow.com/rooms/info/202427), open to discuss room moderation and policy

I'm one of the room owners and we discussed inviting Sloshy to these meta rooms, see [discussion starting here](https://chat.stackoverflow.com/transcript/message/56595043#56595043) for the last round.