### PR TITLE
sloshy.yaml: Add back Userscripters

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -140,6 +140,9 @@ servers:
     - contact: oleg-valter (15810379)
       name: "[dev] SpotDetector"
       id: 244392
+    - contact: vlaz (4541793)
+      name: "Userscript newbies and friends"
+      id: 214345
     - contact: user1271772 (1327177)
       name: "ElectionBot Development (SO)"
       id: 190503


### PR DESCRIPTION
Adding back Userscripters from [the last removal](https://github.com/tripleee/sloshy/commit/42bab07739623b0daa036023d8b50298881829c4). Changed contact.