### PR TITLE
.circleci/config.yml: allow triggering of nightly by API trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,19 @@ workflows:
       - nightly:
           context:
           - sloshy
+
+  manual-scan:
+    when:
+        equal: [ api, << pipeline.trigger_source >> ]
+    jobs:
+      - nightly:
+          filters:
+            branches:
+              only:
+                - master
+          context:
+          - sloshy
+
   test-pushed:
     jobs:
       - test-pushed:


### PR DESCRIPTION
https://support.circleci.com/hc/en-us/articles/12419710425499-How-to-Manually-Trigger-a-Scheduled-Pipeline