### PR TITLE
.github/workflows/test-pushed.yml: bump Python to 3.10

### DIFF
--- a/.github/workflows/test-pushed.yml
+++ b/.github/workflows/test-pushed.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Need this for type|other type hints

Also, bump actions/setup-python to @v5