### PR TITLE
Remove Petəíŕd's Den, formerly "AI stuff"

### DIFF
--- a/sloshy.yaml
+++ b/sloshy.yaml
@@ -102,9 +102,6 @@ servers:
     - contact: gparyani (2477436)
       id: 84778
       name: The Terminal
-    - contact: Pet Linux (28115049)
-      id: 146039
-      name: AI stuff
     - contact: tripleee (468289)
       id: 241
       name: Area 51


### PR DESCRIPTION
As this room is currently deleted, it causes Sloshy's actions to fail (or at least appear as failed). I removed it (the YAML entry) while the staff and moderators are deciding what to do with my room.